### PR TITLE
Add codex-router overlay and expose it in home packages

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -14,6 +14,7 @@ in
       docker-compose
       docker-buildx
 
+      codex-router
       license-generator
       jdk21Pkg
       uv

--- a/nix/overlays/codex-router.nix
+++ b/nix/overlays/codex-router.nix
@@ -1,0 +1,23 @@
+final: _prev: {
+  codex-router = final.buildNpmPackage rec {
+    pname = "codex-router";
+    version = "1.0.0";
+
+    src = final.fetchFromGitHub {
+      owner = "oli799";
+      repo = "codex-router";
+      rev = "1c7a3289196dbd8ef1f829b73bf5f417cbfe6761";
+      hash = "sha256-DljHQFM8hLE3Hs+qGiV+wRf3Y8EqP6uDO4vPo6s7hJ8=";
+    };
+
+    npmDepsHash = "sha256-UFVFe/JN+u/fFHoi5LT2nrBUglZBsZeNBIGTPknDruI=";
+
+    meta = with final.lib; {
+      description = "Switch codex accounts without leaving your terminal";
+      homepage = "https://github.com/oli799/codex-router";
+      license = licenses.mit;
+      maintainers = [ ];
+      mainProgram = "codex-router";
+    };
+  };
+}

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -4,6 +4,7 @@ let
   overlayFiles = [
     ./roots.nix
     ./git-now.nix
+    ./codex-router.nix
   ];
 
   # Apply each overlay and merge results


### PR DESCRIPTION
**Summary**
- Added a new Nix overlay for `codex-router` using `buildNpmPackage` from `oli799/codex-router`.
- Registered the overlay in `nix/overlays/default.nix`.
- Added `codex-router` to the Home Manager package set in `nix/modules/home/packages.nix`.

**Testing**
- Not run (not requested)