### PR TITLE
Add directory-specific AGENTS guidance across the dotfiles repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,130 +1,27 @@
 # AGENTS.md
 
-This file gives coding agents project-specific guidance for this dotfiles
-repository. It applies to the whole repository unless a more specific
-`AGENTS.md` is added in a subdirectory.
+## プロジェクト概要
 
-## Project Overview
+- このリポジトリは `aiwao` ユーザー向けの個人 dotfiles です。
+- `flake.nix` を入口に、Nix で macOS と Linux の開発環境を管理します。
+- macOS は nix-darwin と Home Manager、Linux は Home Manager と
+  system-manager を使います。
+- 手書きの設定ファイルはリポジトリ内に置き、Home Manager の activation
+  でホームディレクトリや XDG 配下へ symlink します。
+- ディレクトリ固有の編集方針や検証方法は、各ディレクトリ配下の
+  `AGENTS.md` を参照してください。
 
-- This is a personal dotfiles repository for user `aiwao`.
-- The main entry point is `flake.nix`.
-- Nix is used to manage:
-  - nix-darwin configuration for macOS.
-  - Home Manager configuration for macOS and Linux.
-  - system-manager configuration for Linux system-level settings.
-- Hand-authored dotfiles live in directories such as `nvim/`, `fish/`, `zsh/`,
-  `wezterm/`, `bash/`, and `efm-langserver/`.
-- Home Manager activation scripts symlink those source directories into the
-  user's home directory. Edit the repository sources, not the generated or
-  symlinked destinations under `~/.config` or `~`.
+## プロジェクトファイル構造
 
-## Important Paths
-
-- `flake.nix`: flake inputs, overlays, app commands, and platform
-  configurations.
-- `nix/modules/home/`: common Home Manager modules.
-- `nix/modules/home/programs/`: program-specific Home Manager modules.
-- `nix/modules/darwin/`: macOS-specific modules.
-- `nix/modules/linux/`: Linux-specific modules.
-- `nix/modules/lib/helpers/`: shared Nix helper functions.
-- `nix/overlays/`: local package overlays.
-- `nvim/`: active Neovim configuration linked by
-  `nix/modules/home/programs/neovim.nix`.
-- `nvim0.11.5/`: versioned or legacy Neovim configuration. Do not change it
-  unless the task explicitly targets it.
-- `fish/`, `zsh/`, `wezterm/`, `bash/`, `efm-langserver/`: shell and tool
-  configs linked by Home Manager activation.
-
-## Commands
-
-Use the commands below from the repository root.
-
-- Build/test the current configuration:
-
-  ```sh
-  nix run .#build
-  ```
-
-- Apply the configuration to the current machine:
-
-  ```sh
-  nix run .#switch
-  ```
-
-- Update flake inputs:
-
-  ```sh
-  nix run .#update
-  ```
-
-- Initial macOS switch command from the README:
-
-  ```sh
-  sudo nix run nix-darwin -- switch --flake .#aiwao
-  ```
-
-Do not run `nix run .#switch`, the direct nix-darwin switch command, or other
-commands that change the user's live system unless the user explicitly asks for
-that. Prefer `nix run .#build` for validation.
-
-Nix flakes ignore untracked files. If validation depends on a newly added file,
-make sure the file is visible to Git before relying on a Nix build result.
-
-## Change Guidelines
-
-- Keep common user-level configuration in `nix/modules/home/`.
-- Put platform-specific behavior in `nix/modules/darwin/` or
-  `nix/modules/linux/`.
-- Add new Home Manager program modules under `nix/modules/home/programs/` and
-  import them from `nix/modules/home/programs/default.nix`.
-- Add common packages to `nix/modules/home/packages.nix` when they should be
-  available on all supported platforms.
-- Add platform-only packages to the corresponding platform module.
-- Keep the existing hard-coded username and home directory conventions unless
-  the user asks to generalize them.
-- Do not update `flake.lock` unless the task is specifically about dependency
-  or package input updates.
-- Treat `nvim/nvim-pack-lock.json` and `nvim0.11.5/lazy-lock.json` as lock
-  files. Update them only when intentionally changing Neovim plugin versions.
-- Avoid editing generated outputs, Nix build results, local caches, or
-  `git-worktree/`.
-
-## Style Notes
-
-- Follow the local style in the file being edited.
-- Nix files use two-space indentation and small modules with explicit imports.
-- Lua files generally use two-space indentation and direct `require(...)`
-  statements.
-- Fish scripts use idiomatic Fish syntax; validate with `fish -n` when
-  changing shell code.
-- Zsh scripts should remain POSIX-aware only where the existing file already is;
-  otherwise use normal Zsh syntax and validate with `zsh -n`.
-- Keep comments useful and brief. Prefer explaining why a non-obvious setting
-  exists over restating what the code says.
-
-## Validation Checklist
-
-Choose the smallest validation that matches the change:
-
-- Nix module or package changes: run `nix run .#build`.
-- Fish changes: run `fish -n` on changed `.fish` files when Fish is available.
-- Zsh changes: run `zsh -n` on changed `.zsh` files or sourced Zsh files when
-  Zsh is available.
-- Lua/Neovim changes: at minimum check syntax for changed Lua files. If
-  practical, start Neovim headlessly to catch load errors.
-- Documentation-only changes: no build is required unless the documentation
-  changes a Nix-visible file that should be checked.
-
-If a validation command cannot be run because Nix or another tool is
-unavailable, report that clearly with the reason.
-
-## Safety
-
-- Respect a dirty worktree. Do not revert, overwrite, or clean up changes you
-  did not make unless the user explicitly asks.
-- Do not use destructive Git or filesystem commands unless the user explicitly
-  requests them.
-- Do not add secrets, host-specific credentials, tokens, or private machine
-  state to this repository.
-- Be careful with activation scripts: they can remove and recreate user files
-  through `link_force`. Review destination paths before changing link behavior.
+- `flake.nix`: flake inputs、overlays、app commands、macOS/Linux の構成定義。
+- `flake.lock`: flake input のロックファイル。
+- `README.md`: セットアップ、build、switch、update の基本手順。
+- `nix/`: Home Manager、nix-darwin、system-manager、overlays の Nix 設定。
+- `nvim/`: 現行の Neovim 設定。
+- `nvim0.11.5/`: バージョン固定または旧世代の Neovim 設定。
+- `fish/`: Fish shell 設定、関数、テーマ。
+- `zsh/`: Zsh 環境変数と読み込み用スクリプト。
+- `wezterm/`: WezTerm の Lua 設定。
+- `bash/`: Bash の profile/rc 設定。
+- `efm-langserver/`: EFM Language Server 設定。
+- `.cobra.yaml`: cobra-cli 設定。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# AGENTS.md
+
+This file gives coding agents project-specific guidance for this dotfiles
+repository. It applies to the whole repository unless a more specific
+`AGENTS.md` is added in a subdirectory.
+
+## Project Overview
+
+- This is a personal dotfiles repository for user `aiwao`.
+- The main entry point is `flake.nix`.
+- Nix is used to manage:
+  - nix-darwin configuration for macOS.
+  - Home Manager configuration for macOS and Linux.
+  - system-manager configuration for Linux system-level settings.
+- Hand-authored dotfiles live in directories such as `nvim/`, `fish/`, `zsh/`,
+  `wezterm/`, `bash/`, and `efm-langserver/`.
+- Home Manager activation scripts symlink those source directories into the
+  user's home directory. Edit the repository sources, not the generated or
+  symlinked destinations under `~/.config` or `~`.
+
+## Important Paths
+
+- `flake.nix`: flake inputs, overlays, app commands, and platform
+  configurations.
+- `nix/modules/home/`: common Home Manager modules.
+- `nix/modules/home/programs/`: program-specific Home Manager modules.
+- `nix/modules/darwin/`: macOS-specific modules.
+- `nix/modules/linux/`: Linux-specific modules.
+- `nix/modules/lib/helpers/`: shared Nix helper functions.
+- `nix/overlays/`: local package overlays.
+- `nvim/`: active Neovim configuration linked by
+  `nix/modules/home/programs/neovim.nix`.
+- `nvim0.11.5/`: versioned or legacy Neovim configuration. Do not change it
+  unless the task explicitly targets it.
+- `fish/`, `zsh/`, `wezterm/`, `bash/`, `efm-langserver/`: shell and tool
+  configs linked by Home Manager activation.
+
+## Commands
+
+Use the commands below from the repository root.
+
+- Build/test the current configuration:
+
+  ```sh
+  nix run .#build
+  ```
+
+- Apply the configuration to the current machine:
+
+  ```sh
+  nix run .#switch
+  ```
+
+- Update flake inputs:
+
+  ```sh
+  nix run .#update
+  ```
+
+- Initial macOS switch command from the README:
+
+  ```sh
+  sudo nix run nix-darwin -- switch --flake .#aiwao
+  ```
+
+Do not run `nix run .#switch`, the direct nix-darwin switch command, or other
+commands that change the user's live system unless the user explicitly asks for
+that. Prefer `nix run .#build` for validation.
+
+Nix flakes ignore untracked files. If validation depends on a newly added file,
+make sure the file is visible to Git before relying on a Nix build result.
+
+## Change Guidelines
+
+- Keep common user-level configuration in `nix/modules/home/`.
+- Put platform-specific behavior in `nix/modules/darwin/` or
+  `nix/modules/linux/`.
+- Add new Home Manager program modules under `nix/modules/home/programs/` and
+  import them from `nix/modules/home/programs/default.nix`.
+- Add common packages to `nix/modules/home/packages.nix` when they should be
+  available on all supported platforms.
+- Add platform-only packages to the corresponding platform module.
+- Keep the existing hard-coded username and home directory conventions unless
+  the user asks to generalize them.
+- Do not update `flake.lock` unless the task is specifically about dependency
+  or package input updates.
+- Treat `nvim/nvim-pack-lock.json` and `nvim0.11.5/lazy-lock.json` as lock
+  files. Update them only when intentionally changing Neovim plugin versions.
+- Avoid editing generated outputs, Nix build results, local caches, or
+  `git-worktree/`.
+
+## Style Notes
+
+- Follow the local style in the file being edited.
+- Nix files use two-space indentation and small modules with explicit imports.
+- Lua files generally use two-space indentation and direct `require(...)`
+  statements.
+- Fish scripts use idiomatic Fish syntax; validate with `fish -n` when
+  changing shell code.
+- Zsh scripts should remain POSIX-aware only where the existing file already is;
+  otherwise use normal Zsh syntax and validate with `zsh -n`.
+- Keep comments useful and brief. Prefer explaining why a non-obvious setting
+  exists over restating what the code says.
+
+## Validation Checklist
+
+Choose the smallest validation that matches the change:
+
+- Nix module or package changes: run `nix run .#build`.
+- Fish changes: run `fish -n` on changed `.fish` files when Fish is available.
+- Zsh changes: run `zsh -n` on changed `.zsh` files or sourced Zsh files when
+  Zsh is available.
+- Lua/Neovim changes: at minimum check syntax for changed Lua files. If
+  practical, start Neovim headlessly to catch load errors.
+- Documentation-only changes: no build is required unless the documentation
+  changes a Nix-visible file that should be checked.
+
+If a validation command cannot be run because Nix or another tool is
+unavailable, report that clearly with the reason.
+
+## Safety
+
+- Respect a dirty worktree. Do not revert, overwrite, or clean up changes you
+  did not make unless the user explicitly asks.
+- Do not use destructive Git or filesystem commands unless the user explicitly
+  requests them.
+- Do not add secrets, host-specific credentials, tokens, or private machine
+  state to this repository.
+- Be careful with activation scripts: they can remove and recreate user files
+  through `link_force`. Review destination paths before changing link behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,30 @@
 # AGENTS.md
 
-## プロジェクト概要
+## Project Overview
 
-- このリポジトリは `aiwao` ユーザー向けの個人 dotfiles です。
-- `flake.nix` を入口に、Nix で macOS と Linux の開発環境を管理します。
-- macOS は nix-darwin と Home Manager、Linux は Home Manager と
-  system-manager を使います。
-- 手書きの設定ファイルはリポジトリ内に置き、Home Manager の activation
-  でホームディレクトリや XDG 配下へ symlink します。
-- ディレクトリ固有の編集方針や検証方法は、各ディレクトリ配下の
-  `AGENTS.md` を参照してください。
+- This repository contains personal dotfiles for the `aiwao` user.
+- `flake.nix` is the main entry point for managing macOS and Linux development
+  environments with Nix.
+- macOS is managed with nix-darwin and Home Manager. Linux is managed with Home
+  Manager and system-manager.
+- Hand-authored configuration files live in this repository and are symlinked
+  into the home directory or XDG paths by Home Manager activation scripts.
+- For directory-specific editing guidance and validation steps, read the
+  `AGENTS.md` file in each relevant subdirectory.
 
-## プロジェクトファイル構造
+## Project File Structure
 
-- `flake.nix`: flake inputs、overlays、app commands、macOS/Linux の構成定義。
-- `flake.lock`: flake input のロックファイル。
-- `README.md`: セットアップ、build、switch、update の基本手順。
-- `nix/`: Home Manager、nix-darwin、system-manager、overlays の Nix 設定。
-- `nvim/`: 現行の Neovim 設定。
-- `nvim0.11.5/`: バージョン固定または旧世代の Neovim 設定。
-- `fish/`: Fish shell 設定、関数、テーマ。
-- `zsh/`: Zsh 環境変数と読み込み用スクリプト。
-- `wezterm/`: WezTerm の Lua 設定。
-- `bash/`: Bash の profile/rc 設定。
-- `efm-langserver/`: EFM Language Server 設定。
-- `.cobra.yaml`: cobra-cli 設定。
+- `flake.nix`: flake inputs, overlays, app commands, and macOS/Linux
+  configuration definitions.
+- `flake.lock`: lock file for flake inputs.
+- `README.md`: basic setup, build, switch, and update instructions.
+- `nix/`: Nix configuration for Home Manager, nix-darwin, system-manager, and
+  overlays.
+- `nvim/`: active Neovim configuration.
+- `nvim0.11.5/`: version-pinned or legacy Neovim configuration.
+- `fish/`: Fish shell configuration, functions, and themes.
+- `zsh/`: Zsh environment variables and sourced scripts.
+- `wezterm/`: WezTerm Lua configuration.
+- `bash/`: Bash profile and rc configuration.
+- `efm-langserver/`: EFM Language Server configuration.
+- `.cobra.yaml`: cobra-cli configuration.

--- a/bash/AGENTS.md
+++ b/bash/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to Bash configuration under `bash/`.
+
+## Directory Overview
+
+- `.bash_profile`: login shell profile linked into the user's home directory.
+- `.bashrc`: interactive Bash configuration linked into the user's home
+  directory.
+
+## Change Guidelines
+
+- Edit repository files, not linked files under the user's home directory.
+- Keep login-only behavior in `.bash_profile`.
+- Keep interactive shell behavior in `.bashrc`.
+- Avoid moving Fish or Zsh-specific setup into Bash files.
+
+## Validation
+
+- Run `bash -n` on changed Bash files when Bash is available.

--- a/efm-langserver/AGENTS.md
+++ b/efm-langserver/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to EFM Language Server configuration under
+`efm-langserver/`.
+
+## Directory Overview
+
+- `config.yaml`: EFM Language Server configuration linked into
+  `~/.config/efm-langserver`.
+
+## Change Guidelines
+
+- Edit repository files, not the linked destination under
+  `~/.config/efm-langserver`.
+- Keep formatter and linter command names aligned with packages provided by
+  `nix/modules/home/programs/neovim.nix` or other Nix modules.
+- Preserve YAML indentation and avoid ad hoc string formatting.
+
+## Validation
+
+- Validate YAML syntax when possible.
+- If adding a formatter or linter dependency, update the corresponding Nix
+  module and run `nix run .#build` from the repository root.

--- a/fish/AGENTS.md
+++ b/fish/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to Fish shell configuration under `fish/`.
+
+## Directory Overview
+
+- `config.fish`: main Fish startup file.
+- `config/`: user config snippets sourced by `config.fish`.
+- `functions/`: autoloaded Fish functions.
+- `themes/`: Fish theme files.
+- `completions/` and `conf.d/`: Fish completion and startup snippet locations.
+
+## Change Guidelines
+
+- Edit repository files, not the linked destination under `~/.config/fish`.
+- Keep reusable commands in `functions/`.
+- Keep startup snippets in `config/`, `conf.d/`, or `config.fish` depending on
+  the existing pattern.
+- Fish plugins are managed from `nix/modules/home/programs/fish.nix`; do not
+  vendor plugin output into this directory.
+- Use idiomatic Fish syntax instead of Bash/Zsh syntax.
+
+## Validation
+
+- Run `fish -n` on changed `.fish` files when Fish is available.
+- For changes that depend on Nix-managed plugins or PATH entries, validate the
+  corresponding Nix module from the repository root with `nix run .#build`.

--- a/nix/AGENTS.md
+++ b/nix/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to files under `nix/`.
+
+## Directory Overview
+
+- `modules/home/`: common Home Manager modules.
+- `modules/home/programs/`: program-specific Home Manager modules.
+- `modules/darwin/`: macOS-specific nix-darwin and Home Manager modules.
+- `modules/linux/`: Linux-specific Home Manager and system-manager modules.
+- `modules/lib/helpers/`: shared helper functions used by modules.
+- `overlays/`: local package overlays.
+- `cachix.nix`: Cachix-related configuration.
+
+## Change Guidelines
+
+- Keep common user-level configuration in `modules/home/`.
+- Put platform-specific behavior in `modules/darwin/` or `modules/linux/`.
+- Add new Home Manager program modules under `modules/home/programs/` and
+  import them from `modules/home/programs/default.nix`.
+- Add common packages to `modules/home/packages.nix` when they should be
+  available on all supported platforms.
+- Add platform-only packages to the corresponding platform module.
+- Keep the existing hard-coded username and home directory conventions unless
+  the user asks to generalize them.
+- Do not update `../flake.lock` unless the task is specifically about
+  dependency or package input updates.
+- Be careful with activation scripts: helpers such as `link_force` can remove
+  and recreate user files. Review destination paths before changing link
+  behavior.
+
+## Validation
+
+- Run from the repository root:
+
+  ```sh
+  nix run .#build
+  ```
+
+- Do not run `nix run .#switch`, direct nix-darwin switch commands, or other
+  live system-changing commands unless the user explicitly asks.
+- Nix flakes ignore untracked files. If validation depends on a newly added
+  file, make sure it is visible to Git before relying on the build result.

--- a/nvim/AGENTS.md
+++ b/nvim/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to the active Neovim configuration under `nvim/`.
+
+## Directory Overview
+
+- `init.lua`: entry point. It adds plugins with `vim.pack.add` and requires
+  plugin/config modules.
+- `lua/aiwao/plugin/`: plugin setup modules.
+- `lua/aiwao/config/`: editor options, keymaps, diagnostics, dashboard, and
+  shared UI behavior.
+- `lua/aiwao/lsp/`: language-server configuration.
+- `ftplugin/`: filetype-specific settings.
+- `nvim-pack-lock.json`: Neovim plugin lock file.
+- `types.lua`: local Lua type helpers or annotations.
+
+## Change Guidelines
+
+- This is the active config linked by `nix/modules/home/programs/neovim.nix`.
+- Keep plugin setup in `lua/aiwao/plugin/` and general editor behavior in
+  `lua/aiwao/config/`.
+- Keep language-server behavior in `lua/aiwao/lsp/` when the change is LSP
+  specific.
+- Update `nvim-pack-lock.json` only when intentionally changing plugin
+  versions.
+- Follow the existing Lua style: two-space indentation and direct
+  `require(...)` calls.
+
+## Validation
+
+- At minimum, syntax-check changed Lua files when possible.
+- If practical, start Neovim headlessly to catch load errors after config
+  changes.
+- For package or language-server availability changes, update the relevant Nix
+  module and validate from the repository root with `nix run .#build`.

--- a/nvim0.11.5/AGENTS.md
+++ b/nvim0.11.5/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to `nvim0.11.5/`.
+
+## Directory Overview
+
+- `init.lua`: entry point for this versioned Neovim configuration.
+- `lua/config/`: shared editor configuration for this config tree.
+- `lua/plugins/`: plugin setup modules.
+- `lazy-lock.json`: plugin lock file for this config tree.
+
+## Change Guidelines
+
+- Treat this as a versioned or legacy Neovim configuration.
+- Do not change files here unless the task explicitly targets `nvim0.11.5/`.
+- Update `lazy-lock.json` only when intentionally changing plugin versions for
+  this tree.
+- Follow the existing Lua style in nearby files.
+
+## Validation
+
+- Syntax-check changed Lua files when possible.
+- If practical, load this config with the intended Neovim version to catch
+  startup errors.

--- a/wezterm/AGENTS.md
+++ b/wezterm/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to WezTerm configuration under `wezterm/`.
+
+## Directory Overview
+
+- `wezterm.lua`: main WezTerm configuration entry point.
+- `keymaps.lua`: key binding definitions required by `wezterm.lua`.
+
+## Change Guidelines
+
+- Edit repository files, not the linked destination under `~/.config/wezterm`.
+- Keep key bindings in `keymaps.lua` unless a setting must live in
+  `wezterm.lua`.
+- Follow the existing Lua style.
+- Keep macOS-specific behavior explicit when adding platform-dependent
+  settings.
+
+## Validation
+
+- Syntax-check changed Lua files when possible.
+- If WezTerm is available, use its config validation facilities or start it
+  after the user asks to apply/test the live configuration.

--- a/zsh/AGENTS.md
+++ b/zsh/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Scope
+
+This file applies to Zsh configuration under `zsh/`.
+
+## Directory Overview
+
+- `.zshenv`: environment setup linked into the user's home directory.
+- `scripts/`: Zsh scripts sourced by the Home Manager Zsh module.
+- `zshrc_is_managed_by_home_manager`: marker/documentation file.
+
+## Change Guidelines
+
+- Edit repository files, not linked files under the user's home directory.
+- Keep environment variables and early shell setup in `.zshenv`.
+- Put reusable interactive helpers in `scripts/`.
+- Home Manager sources every file under `${HOME}/.zsh/scripts/*`; avoid adding
+  non-Zsh files there.
+- Zsh plugins and common init behavior are managed in
+  `nix/modules/home/programs/zsh.nix`.
+
+## Validation
+
+- Run `zsh -n` on changed `.zsh` files and sourced Zsh scripts when Zsh is
+  available.
+- If behavior depends on Home Manager setup, validate the related Nix change
+  from the repository root with `nix run .#build`.


### PR DESCRIPTION
## Summary
- Add a top-level `AGENTS.md` with repository-wide conventions and structure notes.
- Add scoped `AGENTS.md` files for Bash, Fish, Nix, Neovim, legacy Neovim, WezTerm, Zsh, and EFM Language Server directories.
- Document change guidelines and validation steps close to the configs they govern.

## Testing
- Not run (not requested)