### PR TITLE
Enable mullvad-daemon as a systemd service on Linux

### DIFF
--- a/nix/modules/linux/system.nix
+++ b/nix/modules/linux/system.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   username,
   ...
 }: {
@@ -14,6 +15,29 @@
         ${username}:100000:65536
       '';
       replaceExisting = true;
+    };
+  };
+
+  systemd.services.mullvad-daemon = {
+    enable = true;
+    description = "Mullvad VPN daemon";
+    wantedBy = [ "multi-user.target" ];
+    wants = [
+      "network.target"
+      "network-online.target"
+    ];
+    after = [
+      "network-online.target"
+      "NetworkManager.service"
+      "systemd-resolved.service"
+    ];
+    startLimitBurst = 5;
+    startLimitIntervalSec = 20;
+    serviceConfig = {
+      ExecStartPre = "-${pkgs.kmod}/bin/modprobe tun";
+      ExecStart = "${pkgs.mullvad}/bin/mullvad-daemon -v --disable-stdout-timestamps";
+      Restart = "always";
+      RestartSec = 1;
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add a `systemd` service for `mullvad-daemon` in the Linux system module
- Start the daemon after network readiness and related services are available
- Load the `tun` kernel module before launch and keep the service restarted on failure

## Testing
- Not run (not requested)