### PR TITLE
Add a launchd daemon for Mullvad on macOS

### DIFF
--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -68,4 +68,18 @@ in
       };
     };
   };
+
+  launchd.daemons = {
+    mullvad-daemon = {
+      serviceConfig = {
+        ProgramArguments = [
+          "${pkgs.mullvad}/bin/mullvad-daemon"
+          "-v"
+          "--disable-stdout-timestamps"
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+      };
+    };
+  };
 }


### PR DESCRIPTION
## Summary
- Register `mullvad-daemon` as a nix-darwin launchd daemon
- Start the daemon at load time and keep it running
- Pass Mullvad-specific arguments for verbose logging and stable stdout formatting

## Testing
- Not run (not requested)