### PR TITLE
Evaluate Home Manager packages for cleaner flake update summaries

### DIFF
--- a/.github/scripts/flake-package-manifest.nix
+++ b/.github/scripts/flake-package-manifest.nix
@@ -1,18 +1,106 @@
 { system }:
 let
   username = "aiwao";
-  flake = builtins.getFlake (toString ../..);
+  root = ../..;
+  flake = builtins.getFlake (toString root);
+  inherit (flake.inputs) home-manager nixpkgs;
+  lib = nixpkgs.lib;
+
   isDarwin = builtins.match ".*-darwin" system != null;
+  isLinux = builtins.match ".*-linux" system != null;
+  homedir = if isDarwin then "/Users/${username}" else "/home/${username}";
+  dotfilesDir = "${homedir}/ghq/github.com/aiwao/dotfiles";
+
+  pkgs = import nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+    overlays =
+      [
+        flake.inputs.neovim-nightly-overlay.overlays.default
+        (import ../../nix/overlays/default.nix)
+      ]
+      ++ lib.optionals isLinux [
+        flake.inputs.nixgl.overlay
+      ];
+  };
 
   packages =
-    if isDarwin then
-      flake.darwinConfigurations.${username}.config.home-manager.users.${username}.home.packages
-    else
-      flake.homeConfigurations."${username}-${system}".config.home.packages;
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        flake.inputs.catppuccin.homeModules.catppuccin
+
+        {
+          home.username = username;
+          home.homeDirectory = homedir;
+        }
+
+        (
+          {
+            config,
+            lib,
+            ...
+          }:
+          let
+            helpers = import ../../nix/modules/lib/helpers { inherit lib; };
+          in
+          {
+            imports =
+              [
+                (import ../../nix/modules/home {
+                  inherit
+                    pkgs
+                    config
+                    lib
+                    ;
+                  inherit homedir system dotfilesDir;
+                })
+              ]
+              ++ lib.optionals isDarwin [
+                (import ../../nix/modules/darwin {
+                  inherit
+                    pkgs
+                    config
+                    lib
+                    helpers
+                    ;
+                  inherit homedir dotfilesDir;
+                })
+              ]
+              ++ lib.optionals isLinux [
+                flake.inputs.nix-index-database.hmModules.nix-index
+
+                (import ../../nix/modules/linux {
+                  inherit
+                    pkgs
+                    config
+                    lib
+                    helpers
+                    ;
+                  inherit homedir dotfilesDir;
+                })
+              ];
+
+            # Theme assets are irrelevant to package version diffs and can force
+            # platform-specific derivations during cross evaluation.
+            catppuccin.enable = lib.mkForce false;
+            catppuccin.bat.enable = lib.mkForce false;
+            catppuccin.eza.enable = lib.mkForce false;
+            catppuccin.fzf.enable = lib.mkForce false;
+            catppuccin.zsh-syntax-highlighting.enable = lib.mkForce false;
+
+            # The Firefox package should be listed, but this generated settings value
+            # also forces a platform-specific catppuccin derivation.
+            programs.firefox.profiles.default.extensions.settings."FirefoxColor@mozilla.com".settings =
+              lib.mkForce { };
+          }
+        )
+      ];
+    }).config.home.packages;
 
   packageInfo = package: {
-    name = flake.inputs.nixpkgs.lib.getName package;
-    version = flake.inputs.nixpkgs.lib.getVersion package;
+    name = lib.getName package;
+    version = lib.getVersion package;
     drvName = package.name or (baseNameOf (toString package));
     drvPath = toString package.drvPath;
   };

--- a/.github/scripts/flake-package-manifest.nix
+++ b/.github/scripts/flake-package-manifest.nix
@@ -1,42 +1,18 @@
 { system }:
 let
-  root = ../..;
-  flake = builtins.getFlake (toString root);
-  inherit (flake.inputs) nixpkgs;
-  lib = nixpkgs.lib;
-
+  username = "aiwao";
+  flake = builtins.getFlake (toString ../..);
   isDarwin = builtins.match ".*-darwin" system != null;
-  isLinux = builtins.match ".*-linux" system != null;
 
-  pkgs = import nixpkgs {
-    inherit system;
-    config.allowUnfree = true;
-    overlays =
-      [
-        flake.inputs.neovim-nightly-overlay.overlays.default
-        (import ../../nix/overlays/default.nix)
-      ]
-      ++ lib.optionals isLinux [
-        flake.inputs.nixgl.overlay
-      ];
-  };
-
-  packageModules =
-    [
-      (import ../../nix/modules/home/packages.nix { inherit pkgs lib; })
-    ]
-    ++ lib.optionals isDarwin [
-      (import ../../nix/modules/darwin/packages.nix { inherit pkgs lib; })
-    ]
-    ++ lib.optionals isLinux [
-      (import ../../nix/modules/linux/packages.nix { inherit pkgs lib; })
-    ];
-
-  packages = lib.concatMap (module: module.home.packages or [ ]) packageModules;
+  packages =
+    if isDarwin then
+      flake.darwinConfigurations.${username}.config.home-manager.users.${username}.home.packages
+    else
+      flake.homeConfigurations."${username}-${system}".config.home.packages;
 
   packageInfo = package: {
-    name = lib.getName package;
-    version = lib.getVersion package;
+    name = flake.inputs.nixpkgs.lib.getName package;
+    version = flake.inputs.nixpkgs.lib.getVersion package;
     drvName = package.name or (baseNameOf (toString package));
     drvPath = toString package.drvPath;
   };

--- a/.github/scripts/flake-package-manifest.py
+++ b/.github/scripts/flake-package-manifest.py
@@ -6,13 +6,6 @@ import subprocess
 import sys
 
 
-DEFAULT_SYSTEMS = [
-    "aarch64-darwin",
-    "x86_64-linux",
-    "aarch64-linux",
-]
-
-
 def nix_expr(system):
     return (
         'import ./.github/scripts/flake-package-manifest.nix '
@@ -37,9 +30,26 @@ def collect_manifest(system):
     return json.loads(result.stdout)
 
 
+def current_system():
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--raw",
+            "--impure",
+            "--expr",
+            "builtins.currentSystem",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Collect package versions from flake home package modules.",
+        description="Collect package versions from evaluated Home Manager configs.",
     )
     parser.add_argument(
         "--system",
@@ -58,7 +68,7 @@ def validate_systems(systems):
 
 def main():
     args = parse_args()
-    systems = args.systems or DEFAULT_SYSTEMS
+    systems = args.systems or [current_system()]
     validate_systems(systems)
 
     json.dump(

--- a/.github/scripts/flake-package-manifest.py
+++ b/.github/scripts/flake-package-manifest.py
@@ -6,6 +6,13 @@ import subprocess
 import sys
 
 
+DEFAULT_SYSTEMS = [
+    "aarch64-darwin",
+    "x86_64-linux",
+    "aarch64-linux",
+]
+
+
 def nix_expr(system):
     return (
         'import ./.github/scripts/flake-package-manifest.nix '
@@ -30,23 +37,6 @@ def collect_manifest(system):
     return json.loads(result.stdout)
 
 
-def current_system():
-    result = subprocess.run(
-        [
-            "nix",
-            "eval",
-            "--raw",
-            "--impure",
-            "--expr",
-            "builtins.currentSystem",
-        ],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-    return result.stdout.strip()
-
-
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Collect package versions from evaluated Home Manager configs.",
@@ -68,7 +58,7 @@ def validate_systems(systems):
 
 def main():
     args = parse_args()
-    systems = args.systems or [current_system()]
+    systems = args.systems or DEFAULT_SYSTEMS
     validate_systems(systems)
 
     json.dump(

--- a/.github/scripts/flake-update-summary.py
+++ b/.github/scripts/flake-update-summary.py
@@ -146,7 +146,7 @@ def print_package_summary(package_manifest_before, package_manifest_after):
 
     print("## Package updates")
     print()
-    print("Direct `home.packages` evaluated for configured systems.")
+    print("Evaluated Home Manager `config.home.packages` for selected systems.")
     print()
 
     if version_updates:

--- a/.github/scripts/flake-update-summary.py
+++ b/.github/scripts/flake-update-summary.py
@@ -138,6 +138,25 @@ def compare_package_manifests(before_manifest, after_manifest):
     return version_updates, rebuilds, added, removed
 
 
+def format_systems(systems):
+    return ", ".join(f"`{system}`" for system in systems)
+
+
+def group_version_updates(version_updates):
+    groups = {}
+    for system, name, old_version, new_version in version_updates:
+        key = (name, old_version, new_version)
+        groups.setdefault(key, set()).add(system)
+
+    return sorted(
+        [
+            (sorted(systems), name, old_version, new_version)
+            for (name, old_version, new_version), systems in groups.items()
+        ],
+        key=lambda item: (item[1], item[2], item[3], item[0]),
+    )
+
+
 def print_package_summary(package_manifest_before, package_manifest_after):
     version_updates, rebuilds, added, removed = compare_package_manifests(
         package_manifest_before,
@@ -150,10 +169,15 @@ def print_package_summary(package_manifest_before, package_manifest_after):
     print()
 
     if version_updates:
-        print("| System | Package | Before | After |")
+        print("| Systems | Package | Before | After |")
         print("| --- | --- | --- | --- |")
-        for system, name, old_version, new_version in version_updates:
-            print(f"| `{system}` | `{name}` | `{old_version}` | `{new_version}` |")
+        for systems, name, old_version, new_version in group_version_updates(
+            version_updates
+        ):
+            print(
+                f"| {format_systems(systems)} | `{name}` | "
+                f"`{old_version}` | `{new_version}` |"
+            )
     else:
         print("No direct package version changes detected.")
 

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -78,12 +78,14 @@ jobs:
 
           cp "$RUNNER_TEMP/flake.lock.before" flake.lock
           python3 -B .github/scripts/flake-package-manifest.py \
+            --system x86_64-linux \
             > "$RUNNER_TEMP/flake-packages.before.json"
 
           restore_lock
           trap - EXIT
 
           python3 -B .github/scripts/flake-package-manifest.py \
+            --system x86_64-linux \
             > "$RUNNER_TEMP/flake-packages.after.json"
 
       - name: Create pull request body

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -78,14 +78,12 @@ jobs:
 
           cp "$RUNNER_TEMP/flake.lock.before" flake.lock
           python3 -B .github/scripts/flake-package-manifest.py \
-            --system x86_64-linux \
             > "$RUNNER_TEMP/flake-packages.before.json"
 
           restore_lock
           trap - EXIT
 
           python3 -B .github/scripts/flake-package-manifest.py \
-            --system x86_64-linux \
             > "$RUNNER_TEMP/flake-packages.after.json"
 
       - name: Create pull request body


### PR DESCRIPTION
## Summary
- Switch package manifest generation to evaluate full Home Manager configurations instead of raw package modules.
- Group identical package version changes across systems into a single summary row.
- Update script descriptions and summary wording to reflect the new evaluation path.

## Testing
- Not run (not requested)