### PR TITLE
Disable Catppuccin auto-enablement and tighten Neovim runtime options

### DIFF
--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -40,7 +40,5 @@ in
     enable = true;
     autoEnable = false;
     flavor = "mocha";
-    nvim.enable = false;
-    firefox.enable = false;
   };
 }

--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -38,6 +38,7 @@ in
 
   catppuccin = {
     enable = true;
+    autoEnable = false;
     flavor = "mocha";
     nvim.enable = false;
     firefox.enable = false;

--- a/nix/modules/home/programs/neovim.nix
+++ b/nix/modules/home/programs/neovim.nix
@@ -21,6 +21,8 @@ in
   programs.neovim = {
     enable = true;
     sideloadInitLua = true;
+    withPython3 = false;
+    withRuby = false;
 
     plugins = [
       pkgs.vimPlugins.nvim-treesitter.withAllGrammars

--- a/nix/modules/home/programs/neovim.nix
+++ b/nix/modules/home/programs/neovim.nix
@@ -20,6 +20,7 @@ in
 {
   programs.neovim = {
     enable = true;
+    sideloadInitLua = true;
 
     plugins = [
       pkgs.vimPlugins.nvim-treesitter.withAllGrammars


### PR DESCRIPTION
## Summary
- Disable Catppuccin's automatic program enablement while keeping the theme enabled globally.
- Remove the explicit Catppuccin toggles for Neovim and Firefox from the home module.
- Adjust Neovim to sideload `init.lua` and disable unused Python 3 and Ruby support.

## Testing
- Not run (not requested)