### PR TITLE
Add efm-langserver LSP configuration to Neovim

### DIFF
--- a/nvim/lua/aiwao/lsp/config.lua
+++ b/nvim/lua/aiwao/lsp/config.lua
@@ -3,11 +3,11 @@ local configs = {}
 
 ---@type string[]
 local module_list = {
-  "css", "web", "rust", "java"
+  "efm", "css", "web", "rust", "java"
 }
 
 for _, m in ipairs(module_list) do
-  module_config = require("aiwao.lsp." .. m).config
+  local module_config = require("aiwao.lsp." .. m).config
   if module_config ~= nil then
     configs = vim.tbl_extend("force", configs, module_config)
   end

--- a/nvim/lua/aiwao/lsp/efm.lua
+++ b/nvim/lua/aiwao/lsp/efm.lua
@@ -1,0 +1,50 @@
+---@type LSPModule
+local M = {
+  config = {
+    efm = {
+      cmd = { "efm-langserver" },
+      filetypes = {
+        "lua",
+        "python",
+        "go",
+        "html",
+        "svelte",
+        "vue",
+        "astro",
+        "javascriptreact",
+        "javascript.jsx",
+        "typescriptreact",
+        "typescript.tsx",
+        "markdown",
+        "markdown.mdx",
+        "css",
+        "scss",
+        "less",
+        "javascript",
+        "typescript",
+        "graphql",
+        "handlebars",
+        "swift",
+        "json",
+        "jsonc",
+        "json5",
+        "yaml",
+        "dockerfile",
+      },
+      root_markers = {
+        ".git",
+        "package.json",
+      },
+      init_options = {
+        documentFormatting = true,
+        documentRangeFormatting = true,
+        hover = true,
+        documentSymbol = true,
+        codeAction = true,
+        completion = true,
+      },
+    },
+  },
+}
+
+return M


### PR DESCRIPTION
## Summary
- Register `efm` in the shared Neovim LSP config merge list
- Add a new `aiwao.lsp.efm` module that configures `efm-langserver`
- Enable efm support for common web, scripting, markup, and config filetypes
- Set basic root markers and language server capabilities for formatting, hover, symbols, code actions, and completion

## Testing
- Not run (not requested)