### PR TITLE
update neovim plugins

### DIFF
--- a/nvim/lua/aiwao/plugin/fff.lua
+++ b/nvim/lua/aiwao/plugin/fff.lua
@@ -9,7 +9,7 @@ vim.api.nvim_create_autocmd("PackChanged", {
     end
   end,
 })
-vim.pack.add { "https://github.com/dmtrKovalenko/fff.nvim" }
+vim.pack.add { "https://github.com/dmtrKovalenko/fff" }
 
 vim.g.fff = {
   lazy_sync = true,

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -50,7 +50,7 @@
       "src": "https://github.com/MunifTanjim/nui.nvim"
     },
     "nvim": {
-      "rev": "16408d203973da7e43fab87c6f9d3bf7fa98fa8b",
+      "rev": "e068ab5f8261f23f6f71ffd8791ae40315b77b9c",
       "src": "https://github.com/catppuccin/nvim"
     },
     "nvim-dap": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -86,7 +86,7 @@
       "src": "https://github.com/nvim-lua/plenary.nvim"
     },
     "rustaceanvim": {
-      "rev": "6563b3e06bcd214dc999f7791d04176ad1af1402",
+      "rev": "58df5e6355f332b24920767e13400a6c79d5af77",
       "src": "https://github.com/mrcjkb/rustaceanvim"
     },
     "snacks.nvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -54,7 +54,7 @@
       "src": "https://github.com/catppuccin/nvim"
     },
     "nvim-dap": {
-      "rev": "45a69eba683a2c448dd9ecfc4de89511f0646b5f",
+      "rev": "9e848e09a697ee95302a3ef2dd43fd6eb709e570",
       "src": "https://github.com/mfussenegger/nvim-dap"
     },
     "nvim-jdtls": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -70,7 +70,7 @@
       "src": "https://github.com/nvim-treesitter/nvim-treesitter"
     },
     "nvim-ts-context-commentstring": {
-      "rev": "a681c2114cbe52e9a6878d09c9d41c35b800ce5a",
+      "rev": "6141a40173c6efa98242dc951ed4b6f892c97027",
       "src": "https://github.com/JoosepAlviste/nvim-ts-context-commentstring"
     },
     "nvim-web-devicons": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -82,7 +82,7 @@
       "src": "https://github.com/stevearc/oil.nvim"
     },
     "plenary.nvim": {
-      "rev": "b9fd5226c2f76c951fc8ed5923d85e4de065e509",
+      "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
       "src": "https://github.com/nvim-lua/plenary.nvim"
     },
     "rustaceanvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -17,9 +17,9 @@
       "rev": "ac9fa498a9edb96dc3056724ff69d5f40b898453",
       "src": "https://github.com/saecki/crates.nvim"
     },
-    "fff.nvim": {
-      "rev": "541c3f572285e3750e5b2f8341bdc8843f5f745b",
-      "src": "https://github.com/dmtrKovalenko/fff.nvim"
+    "fff": {
+      "rev": "957f222da76f120868defdf9e7204309c3800e5e",
+      "src": "https://github.com/dmtrKovalenko/fff"
     },
     "friendly-snippets": {
       "rev": "6cd7280adead7f586db6fccbd15d2cac7e2188b9",

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -62,7 +62,7 @@
       "src": "https://github.com/mfussenegger/nvim-jdtls"
     },
     "nvim-lspconfig": {
-      "rev": "9ccd58a7949091c0cc2777d4e92a45a209c808c1",
+      "rev": "3371bf298c1f56efc26771ee961f461176958fb5",
       "src": "https://github.com/neovim/nvim-lspconfig"
     },
     "nvim-treesitter": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -78,7 +78,7 @@
       "src": "https://github.com/nvim-tree/nvim-web-devicons"
     },
     "oil.nvim": {
-      "rev": "0fcc83805ad11cf714a949c98c605ed717e0b83e",
+      "rev": "b73018b75affd13fa38e2fc94ef753b465f770d7",
       "src": "https://github.com/stevearc/oil.nvim"
     },
     "plenary.nvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -90,7 +90,7 @@
       "src": "https://github.com/mrcjkb/rustaceanvim"
     },
     "snacks.nvim": {
-      "rev": "ad9ede6a9cddf16cedbd31b8932d6dcdee9b716e",
+      "rev": "882c996cf28183f4d63640de0b4c02ec886d01f2",
       "src": "https://github.com/folke/snacks.nvim"
     }
   }

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -38,7 +38,7 @@
       "src": "https://github.com/nvim-lualine/lualine.nvim"
     },
     "markview.nvim": {
-      "rev": "a55e91f25994617a477d4a0e0b326f9dfa648f80",
+      "rev": "301e431c7b618235f5447d54465c70934bd33668",
       "src": "https://github.com/OXY2DEV/markview.nvim"
     },
     "noice.nvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -34,7 +34,7 @@
       "src": "https://github.com/TheGLander/indent-rainbowline.nvim"
     },
     "lualine.nvim": {
-      "rev": "74114f0df664f14d7c228945693ba68a3b70a794",
+      "rev": "221ce6b2d999187044529f49da6554a92f740a96",
       "src": "https://github.com/nvim-lualine/lualine.nvim"
     },
     "markview.nvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -74,7 +74,7 @@
       "src": "https://github.com/JoosepAlviste/nvim-ts-context-commentstring"
     },
     "nvim-web-devicons": {
-      "rev": "40e9d5a6cc3db11b309e39593fc7ac03bb844e38",
+      "rev": "dfbfaa967a6f7ec50789bead7ef87e336c1fa63c",
       "src": "https://github.com/nvim-tree/nvim-web-devicons"
     },
     "oil.nvim": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -58,7 +58,7 @@
       "src": "https://github.com/mfussenegger/nvim-dap"
     },
     "nvim-jdtls": {
-      "rev": "77ccaeb422f8c81b647605da5ddb4a7f725cda90",
+      "rev": "6e9d953f0b82bccdb834cfde0e893f3119c22592",
       "src": "https://github.com/mfussenegger/nvim-jdtls"
     },
     "nvim-lspconfig": {

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -14,7 +14,7 @@
       "src": "https://github.com/akinsho/bufferline.nvim"
     },
     "crates.nvim": {
-      "rev": "ac9fa498a9edb96dc3056724ff69d5f40b898453",
+      "rev": "694357861ec9ebf12475ddcdd04ea45a0923c32d",
       "src": "https://github.com/saecki/crates.nvim"
     },
     "fff": {


### PR DESCRIPTION
- **neovim: update fff plugin**
- **neovim: update nvim-web-devicons plugin**
- **neovim: update plenary.nvim plugin**
- **neovim: update catppuccin.nvim plugin**
- **neovim: update nvim-ts-context-commentstring plugin**
- **neovim: update crates.nvim plugin**
- **neovim: update lualine.nvim plugin**
- **neovim: update markview.nvim plugin**
- **neovim: update nvim-jdtls plugin**
- **neovim: update nvim-dap plugin**
- **neovim: update snacks.nvim plugin**
- **neovim: update oil.nvim plugin**
- **neovim: update nvim-lspconfig plugin**
- **neovim: update rustaceanvim plugin**
