### PR TITLE
Add nix-vite-plus and install vite-plus globally

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -309,6 +309,26 @@
         "type": "github"
       }
     },
+    "nix-vite-plus": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781875589,
+        "narHash": "sha256-8CWrloMR++Ug6luDkGiicm5NtOWYc9n79e8cym8yop8=",
+        "owner": "ryoppippi",
+        "repo": "nix-vite-plus",
+        "rev": "913c3cee4cb595d133678fb8438ca08f7286e23e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "nix-vite-plus",
+        "type": "github"
+      }
+    },
     "nixgl": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -442,6 +462,7 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
+        "nix-vite-plus": "nix-vite-plus",
         "nixgl": "nixgl",
         "nixpkgs": "nixpkgs_4",
         "system-manager": "system-manager"

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,11 @@
 
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
     nixgl.url = "github:nix-community/nixGL";
+
+    nix-vite-plus = {
+      url = "github:ryoppippi/nix-vite-plus";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = 
@@ -76,6 +81,7 @@
       nix-index-database,
       neovim-nightly-overlay,
       nixgl,
+      nix-vite-plus,
       catppuccin,
       ...
     }: 
@@ -98,6 +104,7 @@
           config.allowUnfree = true;
           overlays = [
             neovim-nightly-overlay.overlays.default
+            nix-vite-plus.overlays.default
             (import ./nix/overlays/default.nix)
           ]
           ++ nixpkgs.lib.optionals isDarwin [

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -44,6 +44,7 @@ in
       nodejs_24
       bun
       pnpm
+      vite-plus
     ];
 
     home.sessionVariables = {

--- a/nix/modules/home/programs/zsh.nix
+++ b/nix/modules/home/programs/zsh.nix
@@ -22,9 +22,6 @@
       export MANPAGER="nvim -c ASMANPAGER -"
 
       export PATH="$HOME/.local/bin:$PATH"
-
-      # Vite+ bin (https://viteplus.dev)
-      . "$HOME/.vite-plus/env"
     '';
 
     plugins = [


### PR DESCRIPTION
## Summary
- Add the `nix-vite-plus` flake input and expose its overlay in the shared Nix configuration
- Install `vite-plus` through Home Manager packages
- Remove the shell-specific `~/.vite-plus/env` sourcing from Zsh since the tool is now provided by Nix

## Testing
- Not run (not requested)