### PR TITLE
flake-update android-studio support

### DIFF
--- a/.github/scripts/flake-package-manifest.nix
+++ b/.github/scripts/flake-package-manifest.nix
@@ -13,7 +13,10 @@ let
 
   pkgs = import nixpkgs {
     inherit system;
-    config.allowUnfree = true;
+    config = {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    };
     overlays =
       [
         flake.inputs.neovim-nightly-overlay.overlays.default

--- a/nix/modules/linux/packages.nix
+++ b/nix/modules/linux/packages.nix
@@ -1,11 +1,15 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  home.packages = with pkgs; [
-    android-studio-full
-    xclip
-    rustdesk
-    gimp
-    vlc
-    nixgl.nixGLIntel
-  ];
+  home.packages =
+    with pkgs;
+    lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
+      android-studio-full
+    ]
+    ++ [
+      xclip
+      rustdesk
+      gimp
+      vlc
+      nixgl.nixGLIntel
+    ];
 }


### PR DESCRIPTION
- **ci(flake-update): accept to android-sdk license in flake-manifest.nix**
- **linux: now android-studio is only for the x86_64-linux**
